### PR TITLE
Removes custom caching logic in favor of Now CDN.

### DIFF
--- a/static/root/now.json
+++ b/static/root/now.json
@@ -4,17 +4,6 @@
     "static": {
         "cleanUrls": true,
         "directoryListing": false,
-        "headers": [
-            {
-                "headers": [
-                    {
-                        "key": "Cache-Control",
-                        "value": "public, max-age=31536000, immutable"
-                    }
-                ],
-                "source": "/_next/**/*.js"
-            }
-        ],
         "renderSingle": true,
         "trailingSlash": false
     },


### PR DESCRIPTION
https://zeit.co/blog/now-cdn

Fixes #69