### PR TITLE
Adds purchase note to WP Test post

### DIFF
--- a/app/(notes)/wp-test/page.mdx
+++ b/app/(notes)/wp-test/page.mdx
@@ -1,5 +1,6 @@
 import { FormattedDate } from "@/components/formatted-date";
 import { Image } from "@/components/image";
+import { Note } from "@/components/note";
 import { createMetadata } from "@/lib/metadata";
 
 export const data = {
@@ -15,6 +16,12 @@ export const metadata = createMetadata(data);
 # {data.title}
 
 <FormattedDate date={data.date} />
+
+<Note>
+  In September 2016, WP Test was purchased by [Brian
+  Krogsgard](https://krogsgard.com) of [Post Status](https://poststatus.com) —
+  read the [announcement](https://poststatus.com/new-wptest-io/).
+</Note>
 
 Building for WordPress means accounting for endless variables: WordPress versions, plugin versions, plugin conflicts, host configurations, browsers, and all the ways people customize WordPress — post formats, custom post types, theme options, theme templates.
 

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -2,7 +2,7 @@ import { InformationCircleIcon } from "@heroicons/react/24/outline";
 
 export function Note({ children }: { children: React.ReactNode }) {
   return (
-    <div className="mb-4 flex items-center gap-2 rounded-md border border-neutral-200 bg-neutral-100 p-4 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-300">
+    <div className="mb-4 flex gap-2 rounded-md border border-neutral-200 bg-neutral-100 p-4 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-300">
       <InformationCircleIcon className="size-5 shrink-0 stroke-neutral-700 dark:stroke-neutral-300" />
       {children}
     </div>


### PR DESCRIPTION
## Summary

The WP Test post reads in present tense with first-person ownership, but the project was sold in 2016 — this adds a note at the top so readers get current context.

## Changes

- Adds a `Note` callout to the top of the WP Test post stating it was purchased by [Brian Krogsgard](https://krogsgard.com) of [Post Status](https://poststatus.com) in September 2016, with a link to the [announcement](https://poststatus.com/new-wptest-io/).
- Top-aligns the `Note` component icon so it sits correctly next to multi-line content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
