### PR TITLE
Adds external Vercel blog posts to notes page

### DIFF
--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import type { Metadata } from "next";
 
@@ -9,9 +10,28 @@ import { createMetadata } from "@/lib/metadata";
 
 type NoteData = {
   date: string;
-  slug: string;
+  href: string;
   title: string;
 };
+
+const externalNotes: NoteData[] = [
+  {
+    date: "2024-09-04",
+    href: "https://vercel.com/blog/whats-new-in-react-19",
+    title: "What's new in React 19",
+  },
+  {
+    date: "2023-08-07",
+    href: "https://vercel.com/blog/introducing-next-js-commerce-2-0",
+    title: "Introducing Next.js Commerce 2.0",
+  },
+  {
+    date: "2022-12-08",
+    href: "https://vercel.com/blog/migrating-a-large-open-source-react-application-to-next-js-and-vercel",
+    title:
+      "Migrating a large, open-source React application to Next.js and Vercel",
+  },
+];
 
 export const metadata: Metadata = createMetadata({
   description: "A collection of notes, thoughts, and articles.",
@@ -27,16 +47,19 @@ function getNoteDirectories() {
     .filter((dir) => fs.existsSync(path.join(notesDir, dir, "page.mdx")));
 }
 
+const linkClassName =
+  "group flex flex-col text-neutral-800 no-underline hover:text-neutral-800 sm:flex-row sm:items-baseline sm:gap-4 dark:text-neutral-200 dark:hover:text-neutral-200";
+
 export default async function NotesPage() {
   const directories = getNoteDirectories();
 
-  const notes: NoteData[] = [];
+  const notes: NoteData[] = [...externalNotes];
 
   for (const directory of directories) {
     const mod = await import(`@/app/(notes)/${directory}/page.mdx`);
     const { date, slug, title } = mod.data;
 
-    notes.push({ date, slug, title });
+    notes.push({ date, href: `/${slug}`, title });
   }
 
   notes.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
@@ -46,14 +69,29 @@ export default async function NotesPage() {
       <h1 className="text-3xl font-bold tracking-tight">Notes</h1>
       <ul className="mt-8 space-y-4">
         {notes.map((note) => (
-          <li key={note.slug}>
-            <Link
-              className="group flex flex-col text-neutral-800 no-underline hover:text-neutral-800 sm:flex-row sm:items-baseline sm:gap-4 dark:text-neutral-200 dark:hover:text-neutral-200"
-              href={`/${note.slug}`}
-            >
-              <FormattedDate className="w-28 shrink-0" date={note.date} />
-              <span className="group-hover:underline">{note.title}</span>
-            </Link>
+          <li key={note.href}>
+            {note.href.startsWith("/") ? (
+              <Link className={linkClassName} href={note.href}>
+                <FormattedDate className="w-28 shrink-0" date={note.date} />
+                <span className="group-hover:underline">{note.title}</span>
+              </Link>
+            ) : (
+              <a
+                className={linkClassName}
+                href={note.href}
+                rel="noopener noreferrer nofollow"
+              >
+                <FormattedDate className="w-28 shrink-0" date={note.date} />
+                <span className="group-hover:underline">
+                  {note.title.split(" ").slice(0, -1).join(" ")}{" "}
+                  <span className="whitespace-nowrap">
+                    {note.title.split(" ").at(-1)}
+                    <ArrowTopRightOnSquareIcon className="mb-0.5 ml-1.5 inline size-4" />
+                  </span>
+                  <span className="sr-only">(external link)</span>
+                </span>
+              </a>
+            )}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary

The notes timeline currently ends in 2013, leaving a decade-long gap with no evidence of the Vercel years. This adds three bylined Vercel blog posts as external links so the timeline reflects that work.

## Changes

- Adds an `externalNotes` array to `app/notes/page.tsx` with three posts and their verified publish dates:
  - [What's new in React 19](https://vercel.com/blog/whats-new-in-react-19) (Sep 4, 2024)
  - [Introducing Next.js Commerce 2.0](https://vercel.com/blog/introducing-next-js-commerce-2-0) (Aug 7, 2023)
  - [Migrating a large, open-source React application to Next.js and Vercel](https://vercel.com/blog/migrating-a-large-open-source-react-application-to-next-js-and-vercel) (Dec 8, 2022)
- Merges external and internal notes into a single date-sorted list
- External entries render as plain anchors with `rel="noopener noreferrer nofollow"` (matching the `Link` component convention), an arrow-out Heroicon, and screen-reader-only "(external link)" text
- Binds the arrow icon to the title's last word with a no-wrap span so it never wraps onto a line by itself on narrow viewports

## Not Planned

- Mirroring or summarizing the posts on-site — links only, so the Vercel URLs carry the content and any rot risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
