### PR TITLE
Updates note titles to sentence case

### DIFF
--- a/.claude/skills/pitch/SKILL.md
+++ b/.claude/skills/pitch/SKILL.md
@@ -9,7 +9,7 @@ Evaluate a post idea against this site's editorial bar and deliver an honest ver
 
 ## The bar
 
-This site's best posts are experience-driven, not steps-driven: career decisions (breaking up with Flash), things built and shipped (WP Test), talks given (WordCamp Atlanta), honest starts (Press Start). The 2026 revival discarded ten posts; the discards were how-to series, vendor reviews, and version-pinned tutorials.
+This site's best posts are experience-driven, not steps-driven: career decisions (breaking up with Flash), things built and shipped (WP Test), talks given (WordCamp Atlanta), honest starts (Press start). The 2026 revival discarded ten posts; the discards were how-to series, vendor reviews, and version-pinned tutorials.
 
 ## Evaluate every pitch on
 

--- a/app/(notes)/flash/page.mdx
+++ b/app/(notes)/flash/page.mdx
@@ -7,7 +7,7 @@ export const data = {
   description:
     "Six years of professional Flash development ended on December 31st, 2012. Time to move on to new platforms.",
   slug: "flash",
-  title: "Breaking Up With Flash",
+  title: "Breaking up with Flash",
 };
 
 export const metadata = createMetadata(data);

--- a/app/(notes)/start/page.mdx
+++ b/app/(notes)/start/page.mdx
@@ -7,7 +7,7 @@ export const data = {
   description:
     "At some point you have to stop making excuses and start. This is me starting.",
   slug: "start",
-  title: "Press Start",
+  title: "Press start",
 };
 
 export const metadata = createMetadata(data);

--- a/app/(notes)/test-and-troubleshoot-wordpress/page.mdx
+++ b/app/(notes)/test-and-troubleshoot-wordpress/page.mdx
@@ -9,7 +9,7 @@ export const data = {
   description:
     "Slides, notes, and resources from my WordCamp Atlanta talk on testing and troubleshooting WordPress plugins and themes.",
   slug: "test-and-troubleshoot-wordpress",
-  title: "How To Test And Troubleshoot WordPress Plugins And Themes",
+  title: "How to test and troubleshoot WordPress plugins and themes",
 };
 
 export const metadata = createMetadata(data);

--- a/app/(notes)/wp-test/page.mdx
+++ b/app/(notes)/wp-test/page.mdx
@@ -8,7 +8,7 @@ export const data = {
   description:
     "Introducing WP Test, an exhaustive set of test data to measure the quality and integrity of WordPress plugins and themes.",
   slug: "wp-test",
-  title: "Introducing WP Test: The Best Tests For WordPress",
+  title: "Introducing WP Test: the best tests for WordPress",
 };
 
 export const metadata = createMetadata(data);


### PR DESCRIPTION
## Summary

Standardizes all note titles to sentence case for a consistent, less formal style across the notes section.

## Changes

- `Breaking Up With Flash` → `Breaking up with Flash`
- `Press Start` → `Press start`
- `How To Test And Troubleshoot WordPress Plugins And Themes` → `How to test and troubleshoot WordPress plugins and themes`
- `Introducing WP Test: The Best Tests For WordPress` → `Introducing WP Test: the best tests for WordPress`
- Updates a passing `Press Start` reference in the pitch skill doc to match

Proper nouns (Flash, WordPress, WP Test) keep their capitalization. The remaining local note and the external Vercel post titles were already sentence case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
