### PR TITLE
Replaces tailwind-merge usage on rel attribute with plain string logic

### DIFF
--- a/components/link.tsx
+++ b/components/link.tsx
@@ -39,9 +39,9 @@ export function Link({
     <a
       className={classNames}
       href={href}
-      rel={cn("noopener noreferrer nofollow", {
-        sponsored: isAffiliateLink,
-      })}
+      rel={
+        "noopener noreferrer nofollow" + (isAffiliateLink ? " sponsored" : "")
+      }
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary

The `Link` component built its external-link `rel` attribute with `cn()` (clsx + tailwind-merge). It happened to produce correct output, but tailwind-merge is a Tailwind class-string conflict resolver — running non-class tokens like `noopener` and `sponsored` through it is fragile and could silently drop or reorder values in a future tailwind-merge version.

## Changes

- Builds `rel` with plain string concatenation: `"noopener noreferrer nofollow" + (isAffiliateLink ? " sponsored" : "")`.
- Keeps `cn()` only for `className`, where it belongs.

Verified with a production build by grepping the prerendered HTML: `/flash` renders `rel="noopener noreferrer nofollow"` on all external links, and `/uses` renders the same plus `sponsored` on exactly the three affiliate links (Robinhood, TradingView, rwrd.io). Lint, format, typecheck, and unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
