### PR TITLE
Revoices the WordPress admin styles note and rewrites its description

### DIFF
--- a/src/routes/(notes)/fix-wordpress-admin-styles-not-loading/+page.md
+++ b/src/routes/(notes)/fix-wordpress-admin-styles-not-loading/+page.md
@@ -1,6 +1,6 @@
 ---
 date: "2013-02-28"
-description: "WordPress admin loading with no CSS? One line in wp-admin/load-styles.php brings the styles back, plus a wp-config alternative that skips the core hack."
+description: "If your WordPress admin loads with no CSS, one line in wp-admin/load-styles.php brings the styles back, plus a wp-config alternative to the core hack."
 slug: "fix-wordpress-admin-styles-not-loading"
 title: "How to fix WordPress admin styles not loading"
 ---

--- a/src/routes/(notes)/fix-wordpress-admin-styles-not-loading/+page.md
+++ b/src/routes/(notes)/fix-wordpress-admin-styles-not-loading/+page.md
@@ -1,6 +1,6 @@
 ---
 date: "2013-02-28"
-description: "Fix missing CSS styles in the WordPress admin with a quick workaround. Change one line of code to restore your dashboard styles instantly."
+description: "WordPress admin loading with no CSS? One line in wp-admin/load-styles.php brings the styles back, plus a wp-config alternative that skips the core hack."
 slug: "fix-wordpress-admin-styles-not-loading"
 title: "How to fix WordPress admin styles not loading"
 ---

--- a/src/routes/(notes)/fix-wordpress-admin-styles-not-loading/+page.md
+++ b/src/routes/(notes)/fix-wordpress-admin-styles-not-loading/+page.md
@@ -14,7 +14,7 @@ title: "How to fix WordPress admin styles not loading"
 
 <FormattedDate date={date} />
 
-If your WordPress admin loads with no CSS, a one-line change can bring it back. File this one away — it won't mean much right now, but you'll be glad you have it when it does.
+Every style in my WordPress admin was gone, and I couldn't tell what was wrong.
 
 <Image
   alt="WordPress admin styles not loading"
@@ -23,9 +23,9 @@ If your WordPress admin loads with no CSS, a one-line change can bring it back. 
   width={768}
 />
 
-Every admin style was gone. I couldn't tell what was wrong. I reinstalled WordPress a couple of times with no luck, then started searching. Well over an hour of articles and suggested hacks later, nothing had worked. The fix finally turned up buried in a sketchy-looking site — I didn't think to save the URL, so I can't credit the author. But it worked.
+I reinstalled WordPress a couple of times with no luck. Well over an hour of articles and suggested hacks later, I finally found the fix buried in a sketchy-looking site. I didn't think to save the URL, or I'd credit the author. But it worked.
 
-One caveat first: I don't encourage hacking WordPress core. In the moment, I wanted my admin back.
+One disclaimer first: I don't encourage hacking WordPress core. In the moment, all I wanted was my admin back so I could work.
 
 In `wp-admin/load-styles.php`, find this line:
 
@@ -33,7 +33,7 @@ In `wp-admin/load-styles.php`, find this line:
 error_reporting(0);
 ```
 
-Change it to this:
+And change it to this:
 
 ```php
 error_reporting( E_ALL | E_STRICT );
@@ -41,13 +41,13 @@ error_reporting( E_ALL | E_STRICT );
 
 Then refresh the admin screen a few times, and the styles come back.
 
-The change doesn't need to stay. Once the styles return, revert the line and everything keeps working.
+You don't need to keep the edit. Once the styles return, revert the line and everything keeps running. I have no idea why that works.
 
-A reader let me know that adding this to `wp-config.php`, above any `require_once` calls, also works — no core file involved:
+A reader let me know that adding this to `wp-config.php`, above any `require_once` calls, works too — no core file hacks involved:
 
 ```php
 define( 'CONCATENATE_SCRIPTS', false );
 define( 'SCRIPT_DEBUG', true );
 ```
 
-I won't claim this fixes every case of missing admin styles, but it fixed mine. Hopefully it saves you the hour I lost.
+I doubt this fixes every case of missing admin styles, but it fixed mine. Hopefully it saves you the hour I lost.


### PR DESCRIPTION
## Summary

This note had drifted a long way from what I wrote in 2013. It went through two rewrite passes, and each one compressed against the previous rewrite rather than the original, so the personal-log register got sanded off a little at a time.

The original text was still in git history at `app/(notes)/.../original.md`, dropped during the SvelteKit conversion. I read the current post against it and put back what mattered.

## Changes

- Leads with the symptom instead of a windup. The old opener told readers to file the post away for later, which is a thinner version of the Evernote line in the original.
- Cuts the search narration from three beats to one. "Started searching", "well over an hour of articles", and "several pages deep into Google" were one beat told three ways.
- Puts back the plain admission that I don't know why the fix works. It's the most honest line in the 2013 post, and both rewrites had dropped it.
- Clears the never-list and repetition slips: `even`, a doubled `also`, `working`/`works` landing back to back, and `back ... back` in one clause.
- Restores `the hour I lost` over `the time I lost`. The number was already there to use.
- Rewrites the description. The old one promised to restore styles "instantly" and never said what the fix was.

## Not planned

Left the title alone. It's what earned the position gain from 14.8 to 11.3 last week, it matches the head queries, and working `CSS` or `dashboard` into it reads as keyword stuffing. Search Console has this at 1.1% CTR from position 11.3, which is about par for the top of page two — the position caps the clicks, not the snippet.

Also left `A reader let me know` rather than restoring `Dan in the comments`. The voice guide names that exact swap as the rule for republished posts.

## References

- manovotny/skills#32 — the `symptom → fix` rule that drove the over-compression now carves out dated notes
- manovotny/skills#33 — no questions in published prose, which came out of an earlier draft of this description

🤖 Generated with [Claude Code](https://claude.com/claude-code)
